### PR TITLE
fix: container consume lot margins on small zoom-level

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -22,7 +22,7 @@
 }
 
 .project__card {
-    @apply flex flex-col bg-[#080808] hover:bg-[#0e0e0e] rounded-[10px] min-h-[320px] max-h-[500px] border border-[#333] transition-all;
+    @apply flex flex-col bg-[#080808] hover:bg-[#0e0e0e] rounded-[10px] min-h-[320px] border border-[#333] transition-all;
 }
 .project__card_img {
     @apply inset-0 box-border p-0 border-none m-auto block min-w-full min-h-full max-w-full max-h-full rounded-tl-[10px] rounded-tr-[10px];

--- a/components/Timeline.vue
+++ b/components/Timeline.vue
@@ -10,9 +10,21 @@ type Timeline = {
 const timelines: Timeline = [
     {
         latest: true,
-        icon: 'ri:brush-4-fill',
+        icon: 'material-symbols:deployed-code',
         title: 'Website UI v2.0.0',
-        date: 'April 20th, 2023',
+        date: 'April 29th, 2023',
+        description: 'Stable release from previous release for this website.',
+    },
+    {
+        icon: 'mdi:sony-playstation',
+        title: 'First Livestream on YouTube',
+        date: 'April 29th, 2023',
+        description: 'Starting first Livestreaming journey on YouTube using PS4.',
+    },
+    {
+        icon: 'mdi:source-branch-plus',
+        title: 'Website UI v2.0.0-beta.1',
+        date: 'April 18th, 2023',
         description:
             "This website is just redesigned into new looking user interface. This design system is inspired from Vercel's Geist UI.",
     },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,7 +5,7 @@ _initHead();
 <template>
     <NuxtLoadingIndicator color="var(--gradient)" :throttle="0" :height="3" />
     <Navigation />
-    <div class="container font-lexend px-10 lg:px-20">
+    <div class="container max-w-full font-lexend px-10 lg:px-20">
         <slot />
     </div>
 </template>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -56,6 +56,8 @@
                     <span class="text-[#3CCF91] font-semibold">Front-end Development</span>.
                     <br />
                     Feel free to get in touch and talk more about your projects.
+                    <br />
+                    Or just want to keep in touch with my other social media.
                 </p>
             </div>
             <div class="mt-10">
@@ -63,10 +65,20 @@
                     <a target="_blank" class="btn__link me-4" href="https://github.com/gifaldyazkaa"
                         ><Icon name="mdi:github" size="1.2rem" class="btn__link_icon" /> GitHub</a
                     >
+                    <a target="_blank" class="btn__link me-4" href="https://twitter.com/falcxxdev"
+                        ><Icon name="mdi:twitter" size="1.2rem" class="btn__link_icon" /> Twitter</a
+                    >
                     <a target="_blank" class="btn__link me-4" href="https://instagram.com/falcxxdev"
                         ><Icon name="mdi:instagram" size="1.2rem" class="btn__link_icon" /> Instagram</a
                     >
-                    <a target="_blank" class="btn__link" href="mailto:me@falcxxdev.cyou"
+                    <br />
+                    <a target="_blank" class="btn__link mt-4 me-4" href="https://discord.com/users/446197585376575489"
+                        ><Icon name="ic:baseline-discord" size="1.2rem" class="btn__link_icon" /> Discord</a
+                    >
+                    <a target="_blank" class="btn__link mt-4 me-4" href="https://youtube.com/@falcxxdev"
+                        ><Icon name="mdi:youtube" size="1.2rem" class="btn__link_icon" /> YouTube</a
+                    >
+                    <a target="_blank" class="btn__link mt-4" href="mailto:me@falcxxdev.cyou"
                         ><Icon name="material-symbols:mail-rounded" size="1.2rem" class="btn__link_icon" /> Email</a
                     >
                 </div>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -61,7 +61,7 @@
                 </p>
             </div>
             <div class="mt-10">
-                <div class="flex flex-row" v-motion-slide-visible-once-bottom>
+                <div class="inline-block" v-motion-slide-visible-once-bottom>
                     <a target="_blank" class="btn__link me-4" href="https://github.com/gifaldyazkaa"
                         ><Icon name="mdi:github" size="1.2rem" class="btn__link_icon" /> GitHub</a
                     >


### PR DESCRIPTION
Here's what fixed

- Container consumes lot margins by adding `max-w-full` class alongside `container` class, 
- Remove `max-h-[520px]` on project card to prevent card shrinking on small zoom-level,
- Synced Timeline component,
- Populated social links on "Keep in Touch" section.